### PR TITLE
T-SQL doesn't use backslash escape characters

### DIFF
--- a/grammars/sql.cson
+++ b/grammars/sql.cson
@@ -274,7 +274,7 @@
           '3':
             'name': 'punctuation.definition.string.end.sql'
         'comment': 'this is faster than the next begin/end rule since sub-pattern will match till end-of-line and SQL files tend to have very long lines.'
-        'match': '(\')[^\'\\\\]*(\')'
+        'match': '(\')[^\']*(\')'
         'name': 'string.quoted.single.sql'
       }
       {


### PR DESCRIPTION
'C:\Test\' is a valid string in T-SQL.  Backslashes don't escape anything.